### PR TITLE
Fix wrapping in INSERT statement

### DIFF
--- a/van8700mai_clean_v15.sql
+++ b/van8700mai_clean_v15.sql
@@ -1,7 +1,4 @@
-INSERT INTO `wp_actionscheduler_actions`
-  (`action_id`,`hook`,`status`,`scheduled_date_gmt`,`scheduled_date_local`,
-   `priority`,`args`,`schedule`,`group_id`,`attempts`,
-   `last_attempt_gmt`,`last_attempt_local`,`claim_id`,`extended_args`)
+INSERT INTO `wp_actionscheduler_actions` (`action_id`,`hook`,`status`,`scheduled_date_gmt`,`scheduled_date_local`,`priority`,`args`,`schedule`,`group_id`,`attempts`,`last_attempt_gmt`,`last_attempt_local`,`claim_id`,`extended_args`)
 VALUES
   (28,'woocommerce_geoip_updater','pending','2025-09-10 09:29:20',
    '2025-09-10 09:29:20',10,'[]',


### PR DESCRIPTION
## Summary
- flatten INSERT column list in `van8700mai_clean_v15.sql`
- verified import into MariaDB

## Testing
- `mariadb --socket=/tmp/mariadb.sock testdb < van8700mai_clean_v15.sql`
- `mariadb --socket=/tmp/mariadb.sock testdb -e "SELECT action_id, hook FROM wp_actionscheduler_actions;"`


------
https://chatgpt.com/codex/tasks/task_b_68ae11343d64832a8afcc5657d02dd26