### PR TITLE
Replace invalid timestamps with NULL in SQL dump

### DIFF
--- a/van8700mai_clean_v15.sql
+++ b/van8700mai_clean_v15.sql
@@ -6,4 +6,4 @@ VALUES
   (28,'woocommerce_geoip_updater','pending','2025-09-10 09:29:20',
    '2025-09-10 09:29:20',10,'[]',
    'O:32:"ActionScheduler_IntervalSchedule":5:{s:22:"\0*\0scheduled_timestamp";i:1757496560;s:18:"\0*\0first_timestamp";i:1756200516;s:13:"\0*\0recurrence";i:1296000;s:49:"\0ActionScheduler_IntervalSchedule\0start_timestamp";i:1757496560;s:53:"\0ActionScheduler_IntervalSchedule\0interval_in_seconds";i:1296000;}',
-   3,0,'0000-00-00 00:00:00','0000-00-00 00:00:00',0,NULL);
+   3,0,NULL,NULL,0,NULL);


### PR DESCRIPTION
## Summary
- replace `0000-00-00 00:00:00` entries with `NULL` in `van8700mai_clean_v15.sql` to avoid zero-date errors under strict SQL modes

## Testing
- `rg "0000-00-00 00:00:00" van8700mai_clean_v15.sql`
- `sudo apt-get install -y default-mysql-server` *(failed: `dpkg: error processing package mysql-server-8.0 (--configure): installed mysql-server-8.0 package post-installation script subprocess returned error exit status 1`)*

------
https://chatgpt.com/codex/tasks/task_b_68ae11ab619c832ab7fe8455fabeb204